### PR TITLE
feat(zig/fib): read index from argv

### DIFF
--- a/Zig/fibonacci/Enarx.toml
+++ b/Zig/fibonacci/Enarx.toml
@@ -1,0 +1,15 @@
+# Arguments
+args = [
+     "7",
+     "21"
+]
+
+# Pre-opened file descriptors
+[[files]]
+kind = "null"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"

--- a/Zig/fibonacci/src/main.zig
+++ b/Zig/fibonacci/src/main.zig
@@ -1,14 +1,19 @@
 const std = @import("std");
 
-fn fibonacci(index: u32) u32 {
-    if (index < 2) return index;
-    return fibonacci(index - 1) + fibonacci(index - 2);
+fn fibonacci(i: u64) u64 {
+    if (i <= 1) return i;
+    return fibonacci(i - 1) + fibonacci(i - 2);
 }
 
 pub fn main() !void {
-    const stdout = std.io.getStdOut().writer();
-    var x: u32 = 7;
+    const alloc: std.mem.Allocator = std.heap.page_allocator;
 
-    try stdout.print("fibonacci of {d} ", .{x});
-    try stdout.print("is: {d} \n ", .{fibonacci(x)}  );
+    var args = try std.process.argsAlloc(alloc);
+    defer alloc.free(args);
+
+    const stdout = std.io.getStdOut().writer();
+    for (args[1..]) |arg| {
+        const i = try std.fmt.parseUnsigned(u64, arg, 10);
+        try stdout.print("Fibonacci sequence number at index {d} is {d}\n", .{i, fibonacci(i)});
+    }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -159,7 +159,7 @@
 
       fibonacci-zig-wasm = final.stdenv.mkDerivation {
         pname = "fibonacci";
-        version = "0.1.0";
+        version = "0.2.0";
 
         src = "${self}/Zig/fibonacci";
 
@@ -180,8 +180,7 @@
         name = final.fibonacci-zig-wasm.pname;
 
         wasm = "${final.fibonacci-zig-wasm}/bin/fibonacci.wasm";
-        # TODO: Read this from repo
-        conf = defaultConf final;
+        conf = "${self}/Zig/fibonacci/Enarx.toml";
       };
 
       echo-tcp-rust-mio-wasm = naersk-lib.buildPackage {


### PR DESCRIPTION
This will work correctly on Enarx once https://github.com/enarx/enarx/issues/2090 is addressed.

```
$ wasmtime ./result/main.wasm 7 21 
Fibonacci sequence number at index 7 is 13
Fibonacci sequence number at index 21 is 10946
```

```
$ enarx run --wasmcfgfile ./result/Enarx.toml ./result/main.wasm
Fibonacci sequence number at index 21 is 10946
Error: Exited with i32 exit status 0
wasm backtrace:
    0: 0x34e9 - <unknown>!<wasm function 15>
```