### PR TITLE
Simplify & reformat AssemblyScript example

### DIFF
--- a/AssemblyScript/fibonacci/fibo.ts
+++ b/AssemblyScript/fibonacci/fibo.ts
@@ -1,14 +1,9 @@
 import "wasi";
-import { Console } from "as-wasi";
 
-export function fibo (n: i32): i32 {
-if(n==1 || n==0){
-  return n;
-}
-else{
-  return fibo(n-1) + fibo(n-2);
-}
+export function fibo(n: i32): i32 {
+  if (n == 0 || n == 1) return n;
+  return fibo(n - 1) + fibo(n - 2);
 }
 
-let a: i32 = fibo(7);
-Console.log(a.toString());
+let res = fibo(7);
+console.log(res.toString());


### PR DESCRIPTION
Signed-off-by: Max Graey <maxgraey@gmail.com>

You don't need `as-wasi` package for simple printing in console. AssemblyScript supports this "out of box".