### PR TITLE
fixup: CLI arguments for C, CPP, Go, Ruby

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ Zig/*/zig-out/
 .idea/
 .vscode/
 result
+*.wasm
+a.out

--- a/C++/fibonacci/Enarx.toml
+++ b/C++/fibonacci/Enarx.toml
@@ -1,0 +1,15 @@
+# Arguments
+args = [
+     "7",
+     "21"
+]
+
+# Pre-opened file descriptors
+[[files]]
+kind = "stdin"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"

--- a/C++/fibonacci/fibonacci.cpp
+++ b/C++/fibonacci/fibonacci.cpp
@@ -1,16 +1,25 @@
-// Simple Program to calculate Fibonacci Sequence of an integer input
 #include <iostream>
+#include <cstdlib>
 using namespace std;
-int FibonacciSequence(int num) {
+
+unsigned int FibonacciSequence(unsigned int num) {
     if(num <= 1) {
         return num ;
     }
     return FibonacciSequence(num-1) + FibonacciSequence(num-2);
 }
-int main(){
-    cout << "Enter the Number" << endl;
-    int n ;
-    cin  >> n ;
 
-    cout << "Fibonacci Sequence term at " << n << "  " << "is " << FibonacciSequence(n) << endl;
+int main(int argc, char* argv[]){
+	unsigned int n;
+	if (argc > 1) {
+		for(int i = 1; i < argc; i++) {
+			n = atoi(argv[i]);
+			cout << "Fibonacci sequence number at index " << n << " is " << FibonacciSequence(n) << endl;
+		}
+	} else {
+		cout << "Which Fibonacci index to find? ";
+		cout.flush();
+		cin >> n;
+		cout << "Fibonacci sequence number at index " << n << " is " << FibonacciSequence(n) << endl;
+	}
 }

--- a/C++/fibonacci/fibonacci.cpp
+++ b/C++/fibonacci/fibonacci.cpp
@@ -1,25 +1,34 @@
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
+#include <string.h>
+
 using namespace std;
 
-unsigned int FibonacciSequence(unsigned int num) {
-    if(num <= 1) {
-        return num ;
-    }
-    return FibonacciSequence(num-1) + FibonacciSequence(num-2);
+unsigned long fib(unsigned long i) {
+  if (i <= 1) {
+    return i;
+  }
+  return fib(i - 1) + fib(i - 2);
 }
 
-int main(int argc, char* argv[]){
-	unsigned int n;
-	if (argc > 1) {
-		for(int i = 1; i < argc; i++) {
-			n = atoi(argv[i]);
-			cout << "Fibonacci sequence number at index " << n << " is " << FibonacciSequence(n) << endl;
-		}
-	} else {
-		cout << "Which Fibonacci index to find? ";
-		cout.flush();
-		cin >> n;
-		cout << "Fibonacci sequence number at index " << n << " is " << FibonacciSequence(n) << endl;
-	}
+int main(int argc, char *argv[]) {
+  if (argc <= 1) {
+    unsigned long n;
+    cout << "Enter a non-negative number:" << endl;
+    cin >> n;
+    cout << "Fibonacci sequence number at index " << n << " is " << fib(n)
+         << endl;
+  } else {
+    for (unsigned int i = 1; i < argc; i++) {
+      errno = 0;
+      unsigned long n = strtoul(argv[i], NULL, 10);
+      if (errno != 0) {
+        cerr << "Failed to parse argument into a number: " << strerror(errno)
+             << endl;
+        exit(1);
+      }
+      cout << "Fibonacci sequence number at index " << n << " is " << fib(n)
+           << endl;
+    }
+  }
 }

--- a/C/fibonacci/Enarx.toml
+++ b/C/fibonacci/Enarx.toml
@@ -1,0 +1,15 @@
+# Arguments
+args = [
+     "7",
+     "21"
+]
+
+# Pre-opened file descriptors
+[[files]]
+kind = "stdin"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"

--- a/C/fibonacci/fibonacci.c
+++ b/C/fibonacci/fibonacci.c
@@ -1,27 +1,34 @@
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-unsigned int FibonacciSequence(unsigned int num) {
-    if(num <= 1) {
-        return num ;
-    }
-    return FibonacciSequence(num-1) + FibonacciSequence(num-2);
+unsigned long fib(unsigned long i) {
+  if (i <= 1) {
+    return i;
+  }
+  return fib(i - 1) + fib(i - 2);
 }
 
-int main(int argc, char* argv[]){
-	unsigned int n;
-    if (argc > 1) {
-    	int i;
-    	for(i = 1; i < argc; i++) {
-    		n = atoi(argv[i]);
-    		printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
-    	}
-    } else {
-    	printf("Which Fibonacci index to find? ");
-    	int matched = scanf("%u", &n);
-    	if (matched < 1) {
-    		n = 10;
-    	}
-    	printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
+int main(int argc, char *argv[]) {
+  if (argc <= 1) {
+    unsigned long n;
+    printf("Enter a non-negative number:\n");
+    if (scanf("%lu", &n) != 1) {
+      fprintf(stderr, "Failed to read number from stdin\n");
+      exit(1);
     }
+    printf("Fibonacci sequence number at index %lu is %lu\n", n, fib(n));
+  } else {
+    for (unsigned int i = 1; i < argc; i++) {
+      errno = 0;
+      unsigned long n = strtoul(argv[i], NULL, 10);
+      if (errno != 0) {
+        fprintf(stderr, "Failed to parse argument into a number: %s\n",
+                strerror(errno));
+        exit(1);
+      }
+      printf("Fibonacci sequence number at index %lu is %lu\n", n, fib(n));
+    }
+  }
 }

--- a/C/fibonacci/fibonacci.c
+++ b/C/fibonacci/fibonacci.c
@@ -1,15 +1,27 @@
 #include <stdio.h>
+#include <stdlib.h>
 
-int FibonacciSequence(int num) {
+unsigned int FibonacciSequence(unsigned int num) {
     if(num <= 1) {
         return num ;
     }
     return FibonacciSequence(num-1) + FibonacciSequence(num-2);
 }
-int main(){
-    printf("Enter the Number\n");
-    int n ;
-    scanf("%d",&n);
 
-    printf("Fibonacci Sequence term at %d is %d " , n , FibonacciSequence(n));
+int main(int argc, char* argv[]){
+	unsigned int n;
+    if (argc > 1) {
+    	int i;
+    	for(i = 1; i < argc; i++) {
+    		n = atoi(argv[i]);
+    		printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
+    	}
+    } else {
+    	printf("Which Fibonacci index to find? ");
+    	int matched = scanf("%u", &n);
+    	if (matched < 1) {
+    		n = 10;
+    	}
+    	printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
+    }
 }

--- a/Go/fibonacci/Enarx.toml
+++ b/Go/fibonacci/Enarx.toml
@@ -1,0 +1,15 @@
+# Arguments
+args = [
+     "7",
+     "21"
+]
+
+# Pre-opened file descriptors
+[[files]]
+kind = "stdin"
+
+[[files]]
+kind = "stdout"
+
+[[files]]
+kind = "stderr"

--- a/Go/fibonacci/go.mod
+++ b/Go/fibonacci/go.mod
@@ -1,0 +1,3 @@
+module github.com/enarx/codex/Go/fibonacci
+
+go 1.17

--- a/Go/fibonacci/main.go
+++ b/Go/fibonacci/main.go
@@ -1,37 +1,45 @@
 package main
 
 import (
+	"bufio"
+	"flag"
 	"fmt"
-	"strconv"
+	"log"
 	"os"
+	"strconv"
 )
 
-func FibonacciSequence(n uint64) uint64 {
-    if n <= 1 {
-        return n
-    }
-    return FibonacciSequence(n-1) + FibonacciSequence(n-2)
+func init() {
+	log.SetFlags(0)
 }
 
-func main(){
-    if len(os.Args) > 1 {
-    	for _, arg := range os.Args[1:] {
-    		n, err := strconv.ParseUint(arg, 10, 64)
-    		if err != nil {
-				fmt.Fprintf(os.Stderr, "%s\n", err)
-				continue
-			}
-    		fmt.Printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
-    	}
-    } else {
-    	var input string
-    	fmt.Print("Which Fibonacci index to find? ")
-    	fmt.Scanln(&input)
-		n, err := strconv.ParseUint(input, 10, 64)
+func fib(n uint64) uint64 {
+	if n <= 1 {
+		return n
+	}
+	return fib(n-1) + fib(n-2)
+}
+
+func main() {
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		fmt.Println("Enter a non-negative number:")
+		sc := bufio.NewScanner(os.Stdin)
+		sc.Scan()
+		b, err := sc.Bytes(), sc.Err()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(-1)
+			log.Fatal("Failed to read stdin: %s", err)
 		}
-		fmt.Printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
-    }
+		args = []string{string(b)}
+	}
+
+	for _, arg := range args {
+		n, err := strconv.ParseUint(arg, 10, 64)
+		if err != nil {
+			log.Fatalf("Failed to parse number: %s", err)
+		}
+		fmt.Printf("Fibonacci sequence number at index %d is %d\n", n, fib(n))
+	}
 }

--- a/Go/fibonacci/main.go
+++ b/Go/fibonacci/main.go
@@ -1,19 +1,37 @@
-// Simple Program to calculate fibonacci of input
-
 package main
 
-import "fmt"
-func FibonacciRecursion(n int) int {
+import (
+	"fmt"
+	"strconv"
+	"os"
+)
+
+func FibonacciSequence(n uint64) uint64 {
     if n <= 1 {
         return n
     }
-    return FibonacciRecursion(n-1) + FibonacciRecursion(n-2)
+    return FibonacciSequence(n-1) + FibonacciSequence(n-2)
 }
 
 func main(){
-    fmt.Print("Enter number : ")
-    var n int
-    fmt.Scanln(&n)
-
-    fmt.Println("Fibonacci of", n , "is", FibonacciRecursion(n));
+    if len(os.Args) > 1 {
+    	for _, arg := range os.Args[1:] {
+    		n, err := strconv.ParseUint(arg, 10, 64)
+    		if err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", err)
+				continue
+			}
+    		fmt.Printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
+    	}
+    } else {
+    	var input string
+    	fmt.Print("Which Fibonacci index to find? ")
+    	fmt.Scanln(&input)
+		n, err := strconv.ParseUint(input, 10, 64)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(-1)
+		}
+		fmt.Printf("Fibonacci sequence number at index %d is %d\n" , n , FibonacciSequence(n));
+    }
 }

--- a/Ruby/fibonacci/fibonacci.rb
+++ b/Ruby/fibonacci/fibonacci.rb
@@ -1,5 +1,15 @@
-def fibonacci( n )
+def FibonacciSequence( n )
   return  n  if ( 0..1 ).include? n
-  ( fibonacci( n - 1 ) + fibonacci( n - 2 ) )
+  ( FibonacciSequence( n - 1 ) + FibonacciSequence( n - 2 ) )
 end
-puts fibonacci( 5 )
+
+if ARGV.length > 0
+  ARGV.each { |arg|
+	n = arg.to_i
+    puts "Fibonacci sequence number at index #{n} is #{FibonacciSequence(n)}"
+  }
+else
+  puts "Which Fibonacci index to find? "
+  n = ARGF.gets.to_i
+  puts "Fibonacci sequence number at index #{n} is #{FibonacciSequence(n)}"
+end

--- a/Zig/fibonacci/Enarx.toml
+++ b/Zig/fibonacci/Enarx.toml
@@ -6,7 +6,7 @@ args = [
 
 # Pre-opened file descriptors
 [[files]]
-kind = "null"
+kind = "stdin"
 
 [[files]]
 kind = "stdout"

--- a/Zig/fibonacci/src/main.zig
+++ b/Zig/fibonacci/src/main.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
         const stdin = std.io.getStdIn();
         defer stdin.close();
 
-        try out.print("No arguments specified, please specify Fibonacci sequence index: \n", .{});
+        try out.print("Enter a non-negative number:\n", .{});
         var buf: [19]u8 = undefined;
         if (try stdin.reader().readUntilDelimiterOrEof(&buf, '\n')) |arg| {
             try print_fibonacci(out, arg);

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
       fibonacci-cpp-wasm =
         final.pkgsCross.wasi32.runCommandCC "fibonacci" {
           pname = "fibonacci";
-          version = "0.1.0";
+          version = "0.2.0";
         }
         ''
           mkdir -p "$out/bin"
@@ -105,8 +105,7 @@
         name = final.fibonacci-cpp-wasm.pname;
 
         wasm = "${final.fibonacci-cpp-wasm}/bin/fibonacci.wasm";
-        # TODO: Read this from repo
-        conf = defaultConf final;
+        conf = "${self}/C++/fibonacci/Enarx.toml";
       };
 
       fibonacci-go-wasm = final.stdenv.mkDerivation rec {

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,7 @@
       fibonacci-c-wasm =
         final.pkgsCross.wasi32.runCommandCC "fibonacci" {
           pname = "fibonacci";
-          version = "0.1.0";
+          version = "0.2.0";
         }
         ''
           mkdir -p "$out/bin"
@@ -85,8 +85,7 @@
         name = final.fibonacci-c-wasm.pname;
 
         wasm = "${final.fibonacci-c-wasm}/bin/fibonacci.wasm";
-        # TODO: Read this from repo
-        conf = defaultConf final;
+        conf = "${self}/C/fibonacci/Enarx.toml";
       };
 
       fibonacci-cpp-wasm =

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
       fibonacci-go-wasm = final.stdenv.mkDerivation rec {
         pname = "fibonacci";
-        version = "0.1.0";
+        version = "0.2.0";
 
         src = "${self}/Go/fibonacci";
 
@@ -137,8 +137,7 @@
         name = final.fibonacci-go-wasm.pname;
 
         wasm = "${final.fibonacci-go-wasm}/bin/fibonacci.wasm";
-        # TODO: Read this from repo
-        conf = defaultConf final;
+        conf = "${self}/Go/fibonacci/Enarx.toml";
       };
 
       fibonacci-rust-wasm = naersk-lib.buildPackage {


### PR DESCRIPTION
C, C++, Go, Ruby receive command line input instead of `stdin`.

Refs #23

Go has a `go.mod` to allow it to be built easily with regular Go.

Overall cleanup for consistency.