### PR TITLE
build(rust): set tokio-http version to 0.1.0

### DIFF
--- a/Rust/tokio-http/Cargo.toml
+++ b/Rust/tokio-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-http"
-version = "0.0.1"
+version = "0.1.0"
 publish = false
 edition = "2021"
 


### PR DESCRIPTION
For consistency with other examples
